### PR TITLE
docs: add how to build stackanetes-deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ kolla-k8s --debug
 ```
 ## Deploy Stackanetes via stackanetes-deployer POD
 
+First you have to build the stackanetes-deployer image. In order to do that,
+simply run the following command from the root of this repository:
+
+```
+docker build -t stackanetes-deployer .
+```
+
 To install Stackanetes vis stackanetes-deployer POD you still have to label your nodes
 and finish `Final host dependencies` step.
 


### PR DESCRIPTION
There was a mention on using a stackanetes-deployer pod that
referenced a stackanetes-deployer image but there was no mention of
where said container could be found nor how to build it. This patch
addresses that in the README.

Signed-off-by: Antoni Segura Puimedon <toni@midokura.com>