### PR TITLE
Fix for namespace specification

### DIFF
--- a/templates/generic-daemonset.yml.j2
+++ b/templates/generic-daemonset.yml.j2
@@ -30,6 +30,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
+  namespace: {{ namespace }}
   name: {{ service_name }}
 spec:
   template:

--- a/templates/generic-deployment.yml.j2
+++ b/templates/generic-deployment.yml.j2
@@ -30,6 +30,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  namespace: {{ namespace }}
   name: {{ service_name }}
 spec:
   replicas: 1

--- a/templates/generic-job.yml.j2
+++ b/templates/generic-job.yml.j2
@@ -2,6 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  namespace: {{ namespace }}
   name: {{ service_name }}
 spec:
   template:


### PR DESCRIPTION
Jobs, Deployments and DaemonSets were created within default namespace
(although namespace for PODs and Services was specified properly).

Signed-off-by: Mateusz Blaszkowski <mateusz.blaszkowski@intel.com>