### PR TITLE
Fix syntax error in rabbitmq configuration

### DIFF
--- a/config/rabbitmq/templates/rabbitmq_clusterer.config.j2
+++ b/config/rabbitmq/templates/rabbitmq_clusterer.config.j2
@@ -1,5 +1,5 @@
 [
   {version, 1},
   {nodes, ["{{ get_ip_address }}"]},
-  {gospel, {node, rabbit@{{ get_ip_address }}}}
+  {gospel, {node, "rabbit@{{ get_ip_address }}"}}
 ].


### PR DESCRIPTION
```
Ignoring external configuration due to error: {4,erl_parse,
                                               ["syntax error before: ",
                                                "'.'"]}
```