### PR TITLE
remove port from cinder-volume

### DIFF
--- a/stackanetes-services/cinder/cinder-volume.yml
+++ b/stackanetes-services/cinder/cinder-volume.yml
@@ -3,8 +3,6 @@ name: cinder-volume
 label: openstack-control-plane
 ceph_required: True
 command: /usr/bin/cinder-volume
-ports:
-  - port: 8776
 dependencies:
   service:
   - mariadb


### PR DESCRIPTION
cinder-volume doesn't listen on 8776 as far as I know - it only monitors rabbitmq for messages passed from cinder-api to do its job.