### PR TITLE
Add scheme to nova.conf [glance]

### DIFF
--- a/config/nova/templates/nova.conf.j2
+++ b/config/nova/templates/nova.conf.j2
@@ -97,7 +97,7 @@ lock_path = /var/lib/nova/tmp
 workers = 8
 
 [glance]
-api_servers = {{ glance_api_host }}:{{ glance_api_port }}
+api_servers = http://{{ glance_api_host }}:{{ glance_api_port }}
 num_retries = 3
 
 [cinder]


### PR DESCRIPTION
```
No protocol specified in for api_server 'http://glance-api:9292', please update [glance] api_servers with fully qualified url including scheme (http / https)
```