### PR TITLE
Fix keystone-api's log openening failures on rkt

### DIFF
--- a/config/keystone/templates/wsgi-keystone.conf.j2
+++ b/config/keystone/templates/wsgi-keystone.conf.j2
@@ -10,8 +10,8 @@ Listen {{ get_ip_address }}:{{ keystone_admin_port }}
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
-    ErrorLog /proc/self/fd/2
-    CustomLog /proc/self/fd/1 combined
+    ErrorLog "|$/bin/cat 1>&2"
+    CustomLog "|/bin/cat" combined
 </VirtualHost>
 
 <VirtualHost *:{{ keystone_admin_port }}>
@@ -23,6 +23,6 @@ Listen {{ get_ip_address }}:{{ keystone_admin_port }}
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
-    ErrorLog /proc/self/fd/2
-    CustomLog /proc/self/fd/1 combined
+    ErrorLog "|$/bin/cat 1>&2"
+    CustomLog "|/bin/cat" combined
 </VirtualHost>


### PR DESCRIPTION
When the rkt container runtime is used, stdout and stderr are Unix sockets to journald, which can't be opened with the open() syscall, leading a the failure below:

```
AH00649: could not open transfer log file /proc/self/fd/1.
AH00015: Unable to open logs
```

This patch uses "cat" to directly write to the stdio fds without
reopening them. It works both with Docker and rkt.