### PR TITLE
This is a third part of PR #51 split

### DIFF
--- a/stackanetes/config/stackanetes.py
+++ b/stackanetes/config/stackanetes.py
@@ -32,6 +32,8 @@ stackanetes_opts = [
     cfg.StrOpt('external_ip', default='10.10.10.10'),
     cfg.StrOpt('image_prefix', default=''),
     cfg.BoolOpt('centralized_logging', default=True),
+    cfg.IntOpt('replicas', default=3, help="Default value of replicas for "
+                                           "deployments")
 ]
 
 stackanetes_opt_group = cfg.OptGroup(name='stackanetes', title="test")

--- a/stackanetes/manifest.py
+++ b/stackanetes/manifest.py
@@ -34,6 +34,7 @@ class Manifest(object):
         self.label = configuration.get('label')
         self.external_ip_enabled = configuration.get('external_ip_enabled',
                                                      False)
+        self.replicas = configuration.get('replicas', CONF.stackanetes.replicas)
         self.memory = CONF.stackanetes.memory
         self.docker_registry = CONF.stackanetes.docker_registry
         self.image_version = CONF.stackanetes.docker_image_tag

--- a/templates/generic/deployment.yml.j2
+++ b/templates/generic/deployment.yml.j2
@@ -33,7 +33,7 @@ metadata:
   namespace: {{ namespace }}
   name: {{ service_name }}
 spec:
-  replicas: 1
+  replicas: {{ replicas }}
   template:
     metadata:
       namespace: {{ namespace }}


### PR DESCRIPTION
Making default replicas number configurable. (default value is 3)

Signed-off-by: DTadrzak <daniel.tadrzak@intel.com>

@pawelsocha 