### PR TITLE
Removing hardcoded rbd_secret_uuid

### DIFF
--- a/config/cinder/templates/cinder.conf.j2
+++ b/config/cinder/templates/cinder.conf.j2
@@ -62,5 +62,5 @@ rbd_max_clone_depth = 5
 rbd_store_chunk_size = 4
 rados_connect_timeout = -1
 rbd_user = cinder
-rbd_secret_uuid = 457eb676-33da-42ec-9a8c-9293d545c337
+rbd_secret_uuid = {{ uuid }}
 report_discard_supported = True

--- a/config/nova/templates/nova-libvirt-cinder-hack.sh.j2
+++ b/config/nova/templates/nova-libvirt-cinder-hack.sh.j2
@@ -4,15 +4,6 @@ sleep 10
 
 KEY=$(ceph auth get-key client.cinder)
 
-cat > /tmp/secret.xml <<EOF
-<secret ephemeral='no' private='no'>
-  <uuid>457eb676-33da-42ec-9a8c-9293d545c337</uuid>
-  <usage type='ceph'>
-    <name>client.cinder secret</name>
-  </usage>
-</secret>
-EOF
-
 virsh secret-define --file /tmp/secret.xml
 
-virsh secret-set-value --secret 457eb676-33da-42ec-9a8c-9293d545c337 --base64 $KEY && rm /tmp/secret.xml
+virsh secret-set-value --secret {{ uuid }} --base64 $KEY && rm /tmp/secret.xml

--- a/config/nova/templates/nova.conf.j2
+++ b/config/nova/templates/nova.conf.j2
@@ -143,7 +143,7 @@ images_type = rbd
 images_rbd_pool = {{ ceph_nova_pool_name }}
 images_rbd_ceph_conf = /etc/ceph/ceph.conf
 rbd_user = cinder
-rbd_secret_uuid = 457eb676-33da-42ec-9a8c-9293d545c337
+rbd_secret_uuid = {{ uuid }}
 disk_cachemodes="network=writeback"
 hw_disk_discard = unmap
 {% endif %}

--- a/config/nova/templates/secret.xml.j2
+++ b/config/nova/templates/secret.xml.j2
@@ -1,0 +1,6 @@
+<secret ephemeral='no' private='no'>
+  <uuid>{{ uuid }}</uuid>
+  <usage type='ceph'>
+    <name>client.cinder secret</name>
+  </usage>
+</secret>

--- a/generate_config_file_sample.sh
+++ b/generate_config_file_sample.sh
@@ -38,6 +38,10 @@ fi
 if  [ ! -f /etc/stackanetes/stackanetes.conf ]
 then
      cp etc/stackanetes.conf.sample /etc/stackanetes/stackanetes.conf
+     # Sometimes OS (especially lightweight OS) doesn't have uuidgen binary.
+     # That's why we use python uuid generator.
+     X=`python -c "import uuid; print uuid.uuid4()"`
+     sed -i "s@#uuid =@uuid = $X@g" /etc/stackanetes/stackanetes.conf
 fi
 
 if [ ! -f /etc/stackanetes/passwords.yml ]

--- a/stackanetes-services/compute/compute-node.yml
+++ b/stackanetes-services/compute/compute-node.yml
@@ -102,6 +102,11 @@ containers:
         container_path: /tmp
         templates:
         - nova/templates/nova-libvirt-cinder-hack.sh.j2
+      - file_name: secret.xml
+        configmap_name: secret-xml
+        container_path: /tmp
+        templates:
+        - nova/templates/secret.xml.j2
     mounts:
       - container_path: /lib/modules
         name: lib-modules

--- a/stackanetes/config/ceph.py
+++ b/stackanetes/config/ceph.py
@@ -20,6 +20,7 @@ ceph_opts = [
     cfg.ListOpt('ceph_mons', default=["192.168.10.1","10.91.10.2"]),
     cfg.StrOpt('ceph_admin_keyring', default='ASDA=='),
     cfg.BoolOpt('ceph_enabled', default=True),
+    cfg.StrOpt('uuid', default=''),
 ]
 
 

--- a/stackanetes/configmap.py
+++ b/stackanetes/configmap.py
@@ -46,6 +46,7 @@ class ConfigMap(object):
             'namespace': CONF.stackanetes['namespace'],
             'monitors': CONF.ceph['ceph_mons'],
             'ceph_admin_keyring': CONF.ceph['ceph_admin_keyring'],
+            'uuid': CONF.ceph['uuid'],
         }
 
     def _set_type(self, template_path):


### PR DESCRIPTION
- Remove hardcoded rbd_secret_uuid
- Move xml file make by nova-libvirt-cinder-hack.sh to be generated by stackanetes.

Signed-off-by: DTadrzak <daniel.tadrzak@intel.com>
@ss7pro: please review it