### PR TITLE
Fix config file generator when oslo-config is not installed.

### DIFF
--- a/generate_config_file_sample.sh
+++ b/generate_config_file_sample.sh
@@ -16,7 +16,7 @@ set -e
 
 GEN_CMD=oslo-config-generator
 
-if ! type "$GEN_CMD" > /dev/null; then
+if ! type -p "$GEN_CMD" > /dev/null ; then
     echo "ERROR: $GEN_CMD not installed on the system."
     exit 1
 fi


### PR DESCRIPTION
When oslo-config was not installed generate_config_file_sample.sh script
was failing without giving right reason.