### PR TITLE
Enable rkt usage for nova compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Stackanetes requires Kubernetes 1.3+ with:
   - [Overlay network] & [DNS add-on],
   - Kubelet running with `--allow-privileged=true`,
 
-While Glance may operate with local storage, a Ceph cluster is needed for Cinder. Nova's live-migration feature requires DNS resolution of the Kubernetes nodes' hostnames.
+While Glance may operate with local storage, a Ceph cluster is needed for Cinder. Nova's live-migration feature requires proper DNS resolution of the Kubernetes nodes' hostnames.
 
 The [rkt] engine can be used in place of the default runtime with Kubernetes 1.4+ and rkt 1.14+. Note however that a known issue about mount propagation flags may prevent the Kubernetes' service account secret from being mounted properly on the Nova's libvirt pod, causing it to fail at startup.
 
@@ -107,7 +107,6 @@ Few users and pools have to be created. The user and pool names can be customize
     ceph osd pool create vms 128
     ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'
     ceph auth get-or-create client.glance mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=images'
-    ceph auth get-or-create client.rgw osd 'allow rwx' mon 'allow rw'
 
 [using bare containers]: https://github.com/ceph/ceph-docker
 [using kubernetes]: https://github.com/ceph/ceph-docker/tree/master/examples/kubernetes

--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ Stackanetes requires Kubernetes 1.3+ with:
 
 While Glance may operate with local storage, a Ceph cluster is needed for Cinder. Nova's live-migration feature requires DNS resolution of the Kubernetes nodes' hostnames.
 
-The [rkt] engine can be used in place of the default runtime for the control plane with Kubernetes 1.4+ and rkt 1.14+. Running the compute plane with it is [not yet] supported due to the lack of `--pid=host`, which is [used] by libvirt to decouple the ownership and lifecycle of the virtual machines from the Nova pods.
+The [rkt] engine can be used in place of the default runtime with Kubernetes 1.4+ and rkt 1.14+. Note however that a known issue about mount propagation flags may prevent the Kubernetes' service account secret from being mounted properly on the Nova's libvirt pod, causing it to fail at startup.
 
 [Overlay network]: http://kubernetes.io/docs/admin/networking/
 [DNS add-on]: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns
 [rkt]: https://github.com/coreos/rkt
-[not yet]: https://github.com/coreos/rkt/issues/3158
-[used]: https://libvirt.org/cgroups.html
+[known issue]: https://github.com/coreos/rkt/issues/3228#issuecomment-249320705
 
 ### High-availability & Networking
 

--- a/demo_openstack.sh
+++ b/demo_openstack.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 set +x
 
-cd /tmp
+# Load environment.
+. env_openstack.sh
 
 # Install command-line tools.
 pip install python-neutronclient python-openstackclient -U
 
-# Load environment.
-. env_openstack.sh
-
 # Import CoreOS / CirrOS images.
+cd /tmp
+
 wget http://download.cirros-cloud.net/0.3.3/cirros-0.3.3-x86_64-disk.img
 wget https://stable.release.core-os.net/amd64-usr/current/coreos_production_openstack_image.img.bz2
 bunzip2 coreos_production_openstack_image.img.bz2
 
 openstack image create CoreOS --container-format bare --disk-format qcow2 --file /tmp/coreos_production_openstack_image.img --public
-openstack image create Cirros --container-format bare --disk-format qcow2 --file /tmp/cirros-0.3.3-x86_64-disk.img --public
+openstack image create CirrOS --container-format bare --disk-format qcow2 --file /tmp/cirros-0.3.3-x86_64-disk.img --public
 
 rm coreos_production_openstack_image.img
 rm cirros-0.3.3-x86_64-disk.img
@@ -35,8 +35,7 @@ openstack flavor create --public m1.xlarge --ram 16384 --disk 160 --vcpus 8
 openstack network create demo-net
 openstack subnet create demo-subnet --allocation-pool start=192.168.0.2,end=192.168.0.254 --network demo-net --subnet-range 192.168.0.0/24 --gateway 192.168.0.1 --dns-nameserver 8.8.8.8 --dns-nameserver 8.8.4.4
 openstack router create demo-router
-openstack port create demo-router-sub --network demo-net --fixed-ip ip-address=192.168.0.1
-openstack router add port demo-router $(openstack port show demo-router-sub -c id -f value)
+neutron router-interface-add demo-router $(openstack subnet show demo-subnet -c id -f value)
 neutron router-gateway-set demo-router ext-net
 
 #openstack security group rule create default --protocol icmp

--- a/neutron/templates/agents.yaml.j2
+++ b/neutron/templates/agents.yaml.j2
@@ -59,6 +59,10 @@ spec:
               mountPath: /usr/sbin/ip
             - name: socket
               mountPath: /var/lib/neutron/kolla/
+            {% if deployment.engine == "rkt" -%}
+            - name: procsys
+              mountPath: /proc/sys
+            {%- endif %}
         - name: neutron-l3-agent
           image: {{ deployment.image.l3 }}
           imagePullPolicy: Always
@@ -101,6 +105,10 @@ spec:
               mountPath: /usr/sbin/ip
             - name: socket
               mountPath: /var/lib/neutron/kolla/
+            {% if deployment.engine == "rkt" -%}
+            - name: procsys
+              mountPath: /proc/sys
+            {%- endif %}
       volumes:
         - name: neutronconf
           configMap:
@@ -132,3 +140,11 @@ spec:
         - name: socket
           hostPath:
             path: /var/lib/neutron/kolla/
+        # TODO(Quentin-M): Remove me
+        # https://github.com/coreos/rkt/issues/3245
+        # https://github.com/coreos/rkt/issues/2694
+        {% if deployment.engine == "rkt" -%}
+        - name: procsys
+          hostPath:
+            path: /proc/sys
+        {%- endif %}

--- a/nova/manifest.jsonnet
+++ b/nova/manifest.jsonnet
@@ -16,6 +16,7 @@ kpm.package({
 
   variables: {
     deployment: {
+      engine: "docker",
       control_node_label: "openstack-control-plane",
       compute_node_label: "openstack-compute-node",
 
@@ -265,9 +266,16 @@ kpm.package({
 
     // Daemonsets.
     {
-      file: "compute/daemonset.yaml.j2",
-      template: (importstr "templates/compute/daemonset.yaml.j2"),
+      file: "compute/compute.yaml.j2",
+      template: (importstr "templates/compute/compute.yaml.j2"),
       name: "nova-compute",
+      type: "daemonset",
+    },
+
+    {
+      file: "compute/libvirt.yaml.j2",
+      template: (importstr "templates/compute/libvirt.yaml.j2"),
+      name: "nova-libvirt",
       type: "daemonset",
     },
 

--- a/nova/templates/compute/compute.yaml.j2
+++ b/nova/templates/compute/compute.yaml.j2
@@ -4,14 +4,13 @@ spec:
   template:
     metadata:
       labels:
-        app: compute-node
+        app: nova-compute
     spec:
       nodeSelector:
         {{ deployment.compute_node_label }}: enabled
       securityContext:
         runAsUser: 0
       hostNetwork: true
-      hostPID: true
       dnsPolicy: ClusterFirst
       containers:
         - name: nova-compute
@@ -37,11 +36,9 @@ spec:
             - name: DEPENDENCY_SERVICE
               value: "keystone-api,glance-api,nova-api"
             - name: DEPENDENCY_DAEMONSET
-              value: "neutron-openvswitch"
+              value: "neutron-openvswitch,nova-libvirt"
             - name: DEPENDENCY_DEPLOYMENT
               value: "neutron-agents"
-            - name: DEPENDENCY_CONTAINER
-              value: "nova-libvirt"
             - name: DEPENDENCY_CONFIG
               value: "/etc/nova/nova.conf,/tmp/nova.sh,/etc/resolv.conf,/etc/ceph/ceph.conf,/etc/ceph/ceph.client.{{ ceph.cinder_user }}.keyring"
           volumeMounts:
@@ -66,58 +63,6 @@ spec:
               name: run
             - mountPath: /sys/fs/cgroup
               name: cgroup
-        - name: nova-libvirt
-          image: {{ deployment.image.libvirt }}
-          imagePullPolicy: Always
-          securityContext:
-            privileged: true
-          env:
-            - name: INTERFACE_NAME
-              value: {{ network.minion_interface_name }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: COMMAND
-              value: "bash /tmp/libvirt.sh"
-            - name: DEPENDENCY_JOBS
-              value: "nova-init,nova-post"
-            - name: DEPENDENCY_SERVICE
-              value: "keystone-api,glance-api,nova-api"
-            - name: DEPENDENCY_DAEMONSET
-              value: "neutron-openvswitch"
-            - name: DEPENDENCY_DEPLOYMENT
-              value: "neutron-agents"
-            - name: DEPENDENCY_CONFIG
-              value: "/etc/libvirt/libvirtd.conf,/tmp/libvirt.sh,/etc/resolv.conf,/etc/ceph/ceph.conf,/etc/ceph/ceph.client.{{ ceph.cinder_user }}.keyring,/tmp/virsh-set-secret.sh"
-          volumeMounts:
-            - name: libvirtdconf
-              mountPath: /configmaps/libvirtd.conf
-            - name: libvirtsh
-              mountPath: /configmaps/libvirt.sh
-            - name: resolvconf
-              mountPath: /configmaps/resolv.conf
-            - name: cephconf
-              mountPath: /configmaps/ceph.conf
-            - name: cephclientcinderkeyring
-              mountPath: /configmaps/ceph.client.{{ ceph.cinder_user }}.keyring
-            - name: virshsetsecretsh
-              mountPath: /configmaps/virsh-set-secret.sh
-            - name: libmodules
-              mountPath: /lib/modules
-              readOnly: true
-            - name: varlibnova
-              mountPath: /var/lib/nova
-            - name: varliblibvirt
-              mountPath: /var/lib/libvirt
-            - name: run
-              mountPath: /run
-            - name: cgroup
-              mountPath: /sys/fs/cgroup
       volumes:
         - name: novaconf
           configMap:
@@ -137,9 +82,6 @@ spec:
         - name: libvirtdconf
           configMap:
             name: nova-libvirtdconf
-        - name: libvirtsh
-          configMap:
-            name: nova-libvirtsh
         - name: virshsetsecretsh
           configMap:
             name: nova-virshsetsecretsh

--- a/nova/templates/compute/libvirt.yaml.j2
+++ b/nova/templates/compute/libvirt.yaml.j2
@@ -1,0 +1,115 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+spec:
+  template:
+    metadata:
+      labels:
+        app: nova-libvirt
+      {% if deployment.engine == "rkt" -%}
+      annotations:
+        rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
+      {%- endif %}
+    spec:
+      nodeSelector:
+        {{ deployment.compute_node_label }}: enabled
+      securityContext:
+        runAsUser: 0
+      hostNetwork: true
+      {% if deployment.engine != "rkt" -%}
+      hostPID: true
+      {%- endif %}
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: nova-libvirt
+          image: {{ deployment.image.libvirt }}
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+            - name: INTERFACE_NAME
+              value: {{ network.minion_interface_name }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: COMMAND
+              value: "bash /tmp/libvirt.sh"
+            - name: DEPENDENCY_JOBS
+              value: "nova-init,nova-post"
+            - name: DEPENDENCY_SERVICE
+              value: "keystone-api,glance-api,nova-api"
+            - name: DEPENDENCY_DAEMONSET
+              value: "neutron-openvswitch"
+            - name: DEPENDENCY_DEPLOYMENT
+              value: "neutron-agents"
+            - name: DEPENDENCY_CONFIG
+              value: "/etc/libvirt/libvirtd.conf,/tmp/libvirt.sh,/etc/resolv.conf,/etc/ceph/ceph.conf,/etc/ceph/ceph.client.{{ ceph.cinder_user }}.keyring,/tmp/virsh-set-secret.sh"
+          volumeMounts:
+            - name: libvirtdconf
+              mountPath: /configmaps/libvirtd.conf
+            - name: libvirtsh
+              mountPath: /configmaps/libvirt.sh
+            - name: resolvconf
+              mountPath: /configmaps/resolv.conf
+            - name: cephconf
+              mountPath: /configmaps/ceph.conf
+            - name: cephclientcinderkeyring
+              mountPath: /configmaps/ceph.client.{{ ceph.cinder_user }}.keyring
+            - name: virshsetsecretsh
+              mountPath: /configmaps/virsh-set-secret.sh
+            - name: varlibnova
+              mountPath: /var/lib/nova
+            - name: varliblibvirt
+              mountPath: /var/lib/libvirt
+            - name: run
+              mountPath: /run
+            {% if deployment.engine != "rkt" -%}
+            - name: libmodules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+            {%- endif %}
+      volumes:
+        - name: novaconf
+          configMap:
+            name: nova-novaconf
+        - name: resolvconf
+          configMap:
+            name: nova-resolvconf
+        - name: cephconf
+          configMap:
+            name: nova-cephconf
+        - name: cephclientcinderkeyring
+          configMap:
+            name: nova-cephclientcinderkeyring
+        - name: libvirtdconf
+          configMap:
+            name: nova-libvirtdconf
+        - name: libvirtsh
+          configMap:
+            name: nova-libvirtsh
+        - name: virshsetsecretsh
+          configMap:
+            name: nova-virshsetsecretsh
+        - name: varlibnova
+          hostPath:
+            path: /var/lib/nova
+        - name: varliblibvirt
+          hostPath:
+            path: /var/lib/libvirt
+        - name: run
+          hostPath:
+            path: /run/
+        {% if deployment.engine != "rkt" -%}
+        - name: libmodules
+          hostPath:
+            path: /lib/modules
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        {%- endif %}

--- a/nova/templates/configmaps/libvirt.sh.yaml.j2
+++ b/nova/templates/configmaps/libvirt.sh.yaml.j2
@@ -29,6 +29,11 @@ data:
         chmod 755 /var/log/kolla/libvirt
     fi
 
+    {%- if deployment.engine == "rkt" %}
+    mount -o remount,ro /sys/fs/selinux
+    mount -o remount,gid=5,mode=620,ptmxmode=666 -t devpts devpts /dev/pts
+    {%- endif %}
+    
     {%- if ceph.enabled %}
     bash /tmp/virsh-set-secret.sh &
     {%- endif %}

--- a/nova/templates/configmaps/virsh-set-secret.sh.yaml.j2
+++ b/nova/templates/configmaps/virsh-set-secret.sh.yaml.j2
@@ -5,7 +5,7 @@ data:
     #!/bin/bash
     set -ex
 
-    sleep 10
+    sleep 30
 
     cat > /tmp/secret.xml <<EOF
     <secret ephemeral='no' private='no'>

--- a/stackanetes/parameters.yaml
+++ b/stackanetes/parameters.yaml
@@ -1,4 +1,6 @@
 deployment:
+  # Underlying container runtime to use.
+  engine: docker
   # Number of replicas of HA services to deploy.
   replicas: 1
   # Labels of the nodes on which services are deployed.

--- a/stackanetes/parameters.yaml
+++ b/stackanetes/parameters.yaml
@@ -55,8 +55,6 @@ ceph:
   glance_pool: "images"
   glance_keyring: ""
   nova_pool: "vms"
-  rgw_user: rgw
-  rgw_keyring: ""
   # Random uuid used for Nova / Cinder communication.
   # Should not be modified after the initial deployment.
   secret_uuid: bbc5b4d5-6fca-407d-807d-06a4f4a7bccb


### PR DESCRIPTION
- The compute daemonset is now split into two different daemonset (`nova-compute`, `nova-libvirt`) (as discussed offline).
- In order to have the `--pid=host` feature on `nova-libvirt` with rkt, `stage1-fly` is used for it specifically.
- Some mounts with rkt are skipped because unnecessary (`/lib/modules`) or even harmful (`/sys/fs/cgroup`). On the other hand, some mounts are remounted (`/sys/fs/selinux`, `/dev/pts`) to get the required modes. In Neutron, we mount `/proc/sys` from the host to get RW without creating new scripts.