### PR TITLE
Fix problem with creating New Project via Horizon.

### DIFF
--- a/nova/manifest.jsonnet
+++ b/nova/manifest.jsonnet
@@ -146,7 +146,7 @@ kpm.package({
     {
       file: "configmaps/openrc.yaml.j2",
       template: (importstr "templates/configmaps/openrc.yaml.j2"),
-      name: "openrc",
+      name: "nova-openrc",
       type: "configmap",
     },
 

--- a/nova/manifest.jsonnet
+++ b/nova/manifest.jsonnet
@@ -144,6 +144,13 @@ kpm.package({
     },
 
     {
+      file: "configmaps/openrc.yaml.j2",
+      template: (importstr "templates/configmaps/openrc.yaml.j2"),
+      name: "openrc",
+      type: "configmap",
+    },
+
+    {
       file: "configmaps/drain-conf.yaml.j2",
       template: (importstr "templates/configmaps/drain-conf.yaml.j2"),
       name: "nova-drainconf",

--- a/nova/templates/configmaps/openrc.yaml.j2
+++ b/nova/templates/configmaps/openrc.yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  openrc: |+
+    export OS_PROJECT_DOMAIN_ID={{ keystone.domain_name }}
+    export OS_USER_DOMAIN_ID={{ keystone.domain_name }}
+    export OS_PROJECT_NAME={{ keystone.admin_project_name }}
+    export OS_USERNAME={{ keystone.admin_user }}
+    export OS_PASSWORD={{ keystone.admin_password }}
+    export OS_TENANT_NAME={{ keystone.tenant_name }}
+    export OS_AUTH_URL="{{ keystone.auth_url }}/v3"
+    export OS_IDENTITY_API_VERSION=3

--- a/nova/templates/configmaps/post.sh.yaml.j2
+++ b/nova/templates/configmaps/post.sh.yaml.j2
@@ -14,3 +14,6 @@ data:
     {%- endif %}
 
     ansible localhost -vvv -m kolla_keystone_user -a "project=service user={{ keystone.nova_user }} password={{ keystone.nova_password }} role=admin region_name={{ keystone.nova_region_name }} auth='{{ keystone.auth }}'" -e "{'openstack_nova_auth':{{ keystone.auth }}}"
+
+    source /tmp/openrc
+    openstack role create _member_ --or-show

--- a/nova/templates/jobs/post.yaml.j2
+++ b/nova/templates/jobs/post.yaml.j2
@@ -45,4 +45,4 @@ spec:
             name: nova-postsh
         - name: openrc
           configMap:
-            name: openrc
+            name: nova-openrc

--- a/nova/templates/jobs/post.yaml.j2
+++ b/nova/templates/jobs/post.yaml.j2
@@ -36,7 +36,13 @@ spec:
           volumeMounts:
             - name: postsh
               mountPath: /configmaps/post.sh
+            - name: openrc
+              mountPath: /tmp/openrc
+              subPath: openrc
       volumes:
         - name: postsh
           configMap:
             name: nova-postsh
+        - name: openrc
+          configMap:
+            name: openrc


### PR DESCRIPTION
Extend functionality of nova-post (create role _member_) in order to allow
creating New Project via horizon.

Signed-off-by: DTadrzak <daniel.tadrzak@intel.com>