### PR TITLE
Generate Horizon assets offline

### DIFF
--- a/horizon/templates/configmaps/local_settings.yaml.j2
+++ b/horizon/templates/configmaps/local_settings.yaml.j2
@@ -11,7 +11,8 @@ data:
     DEBUG = {{ misc.debug }}
     TEMPLATE_DEBUG = DEBUG
 
-    COMPRESS_OFFLINE = False
+    COMPRESS_OFFLINE = True
+    COMPRESS_CSS_HASHING_METHOD = "hash"
 
     # WEBROOT is the location relative to Webserver root
     # should end with a slash.

--- a/horizon/templates/configmaps/start.sh.yaml.j2
+++ b/horizon/templates/configmaps/start.sh.yaml.j2
@@ -10,4 +10,9 @@ data:
     rm -rf /var/run/apache2/*
     APACHE_DIR="apache2"
 
+    # Compress Horizon's assets.
+    /var/lib/kolla/venv/bin/manage.py collectstatic --noinput
+    /var/lib/kolla/venv/bin/manage.py compress
+    rm -rf /tmp/_tmp_.secret_key_store.lock /tmp/.secret_key_store
+
     apache2 -DFOREGROUND


### PR DESCRIPTION
This fixes an issue that happens when Horizon is used behind a
load-balancer that doesn't do sticky-sessions. The first time the user
would open Horizon, the reached controller would generate the assets but
the browser might ask another server for these assets. And because
apache2 serves these files as static files, the other server's
controller wouldn't be hit and generate the missing asserts.

It also forces the hashing method to 'hash', which is the current
default for Horizon, that is equivalent to the documented 'content'
method in django-compressor 1.4 (https://goo.gl/PPhhWq).