### PR TITLE
Use memcached to store nova-consoleauth's tokens

### DIFF
--- a/nova/manifest.jsonnet
+++ b/nova/manifest.jsonnet
@@ -128,6 +128,10 @@ kpm.package({
       metadata_secret: "password",
     },
 
+    memcached: {
+      address: "memcached:11211",
+    },
+    
     misc: {
       debug: false,
       workers: 8,

--- a/nova/templates/configmaps/nova.conf.yaml.j2
+++ b/nova/templates/configmaps/nova.conf.yaml.j2
@@ -128,3 +128,9 @@ data:
 
     [serial_console]
     enabled = False
+
+    [cache]
+    enabled = true
+    backend = oslo_cache.memcache_pool
+    memcache_servers = {{ memcached.address }}
+    


### PR DESCRIPTION
Otherwise, the credentials generated are stored locally (in memory)
and it makes running multiple load-balanced instances of
nova-consoleauth difficult.