### PR TITLE
Adding new type of readiness probe for mariadb

### DIFF
--- a/mariadb/manifest.jsonnet
+++ b/mariadb/manifest.jsonnet
@@ -146,6 +146,13 @@ kpm.package({
       type: "configmap",
     },
 
+    {
+      file: "configmaps/mariadb-readiness.py.yaml.j2",
+      template: (importstr "templates/configmaps/mariadb-readiness.py.yaml.j2"),
+      name: "mariadb-readiness",
+      type: "configmap",
+    },
+
     // Jobs.
     {
       file: "init.yaml.j2",

--- a/mariadb/templates/configmaps/mariadb-readiness.py.yaml.j2
+++ b/mariadb/templates/configmaps/mariadb-readiness.py.yaml.j2
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  mariadb-readiness.py: |+
+    #!/usr/bin/env python
+    import os
+    import sys
+    import time
+    import pymysql
+
+    DB_HOST = "127.0.0.1"
+    DB_PORT = int(os.environ.get('MARIADB_SERVICE_PORT', '3307'))
+
+    while True:
+        try:
+            pymysql.connections.Connection(host=DB_HOST, port=DB_PORT,
+                                           connect_timeout=1)
+            sys.exit(0)
+        except pymysql.err.OperationalError as e:
+            code, message = e.args
+
+            if code == 2003 and 'time out' in message:
+                print('Connection timeout, sleeping')
+                time.sleep(1)
+                continue
+            if code == 1045:
+                print('Mysql ready to use. Exiting')
+                sys.exit(0)
+
+            # other error
+            raise

--- a/mariadb/templates/daemonset.yaml.j2
+++ b/mariadb/templates/daemonset.yaml.j2
@@ -37,8 +37,10 @@ spec:
           ports:
             - containerPort: {{ network.port.mariadb }}
           readinessProbe:
-            tcpSocket:
-              port: {{ network.port.mariadb }}
+            exec:
+              command:
+                - python
+                - mariadb-readiness.py
           volumeMounts:
             - name: mycnfd
               mountPath: /etc/my.cnf.d
@@ -79,6 +81,9 @@ spec:
             - name: replicas
               mountPath: /tmp/replicas.py
               subPath: replicas.py
+            - name: readiness
+              mountPath: /mariadb-readiness.py
+              subPath: mariadb-readiness.py
       volumes:
         - name: mycnfd
           emptyDir: {}
@@ -118,6 +123,9 @@ spec:
         - name: replicas
           configMap:
             name: mariadb-replicas
+        - name: readiness
+          configMap:
+            name: mariadb-readiness
         - name: mysql
           hostPath:
             path: /var/lib/mysql-openstack-{{ database.cluster_name }}


### PR DESCRIPTION
Adding new type of readiness probe: exec and script that check whethermariadb is ready.

Signed-off-by: DTadrzak <daniel.tadrzak@intel.com>