### PR TITLE
Fixes for mariadb single instance deployment and mariadb.pid cleanup.

### DIFF
--- a/mariadb/manifest.jsonnet
+++ b/mariadb/manifest.jsonnet
@@ -9,7 +9,7 @@ kpm.package({
     name: "stackanetes/mariadb",
     expander: "jinja2",
     author: "Mateusz Blaszkowski",
-    version: "0.1.0",
+    version: "0.3.0",
     description: "mariadb",
     license: "Apache 2.0",
   },

--- a/mariadb/templates/configmaps/start.sh.yaml.j2
+++ b/mariadb/templates/configmaps/start.sh.yaml.j2
@@ -9,11 +9,23 @@ data:
     sudo chown mysql: /var/lib/mysql
 
     REPLICAS=$(python /tmp/replicas.py)
+    INIT_MARKER="/var/lib/mysql/init_done"
+
+    # Remove mariadb.pid if exists
+    if [[ -f /var/lib/mysql/mariadb.pid ]]; then
+        if [[ `pgrep -c $(cat /var/lib/mysql/mariadb.pid)` -eq 0 ]]; then
+            rm -vf /var/lib/mysql/mariadb.pid
+        fi
+    fi
 
     if [ "$REPLICAS" -eq 1 ] ; then
-        echo "Creating one-instance MariaDB cluster."
-        bash /tmp/bootstrap-db.sh
-        mysqld_safe --defaults-file=/etc/my.cnf \
+        if [[ ! -f ${INIT_MARKER} ]]; then
+            cd /var/lib/mysql 
+            echo "Creating one-instance MariaDB."
+            bash /tmp/bootstrap-db.sh
+            touch ${INIT_MARKER}
+        fi
+        exec mysqld_safe --defaults-file=/etc/my.cnf \
                     --console \
                     --wsrep-new-cluster \
                     --wsrep_cluster_address='gcomm://'


### PR DESCRIPTION
prevent multiple initialization. Second fix ensures that mariadb.pid is
removed when there's no coresponding processes present.