### PR TITLE
Add virt_type parameter to Nova

### DIFF
--- a/nova/manifest.jsonnet
+++ b/nova/manifest.jsonnet
@@ -68,6 +68,12 @@ kpm.package({
     },
 
     nova: {
+      // Configures the underlying virtualization engine for VM guests.
+      // Useful when native virtualization is not supported for instance, in
+      // which case, qemu can be used. For the list of supported technologies,
+      // see http://docs.openstack.org/newton/config-reference/compute/hypervisors.html
+      virt_type: "kvm",
+      
       drain_timeout: 60,
     },
 

--- a/nova/templates/configmaps/nova.conf.yaml.j2
+++ b/nova/templates/configmaps/nova.conf.yaml.j2
@@ -95,6 +95,8 @@ data:
     [libvirt]
     connection_uri = "qemu+tcp://{{ network.ip_address }}/system"
     images_type = qcow2
+    virt_type = {{ nova.virt_type }}
+
     # Enabling live-migration without hostname resolution
     live_migration_inbound_addr = {{ network.ip_address }}
 


### PR DESCRIPTION
This arose when deploying Stackanetes on non VT-ready AWS instances for testing / demo'ing.