### PR TITLE
Enforce 'replicas: 1' on glance-api when local storage is used

### DIFF
--- a/glance/templates/api/deployment.yaml.j2
+++ b/glance/templates/api/deployment.yaml.j2
@@ -1,7 +1,11 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 spec:
+  {% if ceph.enabled -%}
   replicas: {{ deployment.control_replicas }}
+  {% else -%}
+  replicas: 1
+  {% endif -%}
   template:
     metadata:
       labels:


### PR DESCRIPTION
When local storage is used, running multiple instances of
glance-api causes image data to be scattered across multiple containers
and nodes. Therefore, when nova or the glance CLI wants to download an
image, if the request doesn't hit the instance that has the data (due to
load balancing), no data is returned - generating either an exception or
an another unexpected behavior.