### PR TITLE
Make Traefik use the port that is defined in the meta package

### DIFF
--- a/traefik/manifest.jsonnet
+++ b/traefik/manifest.jsonnet
@@ -24,10 +24,8 @@ kpm.package({
     },
 
     network: {
-      port: {
-        http: 30080,
-        https: 30443,
-        ui: 8080,
+      ingress: {
+        port: 30080,
       },
     },
   },

--- a/traefik/manifest.jsonnet
+++ b/traefik/manifest.jsonnet
@@ -48,13 +48,6 @@ kpm.package({
       name: "traefik",
       type: "service",
     },
-
-    {
-      file: "service-ui.yaml.j2",
-      template: (importstr "templates/service-ui.yaml.j2"),
-      name: "traefik-ui",
-      type: "service",
-    },
   ],
 
   deploy: [

--- a/traefik/templates/deployment.yaml.j2
+++ b/traefik/templates/deployment.yaml.j2
@@ -17,5 +17,4 @@ spec:
         command: ["./traefik", "--web", "--kubernetes"]
         ports:
           - containerPort: 80
-          - containerPort: 443
-          - containerPort: 8080
+

--- a/traefik/templates/service-ui.yaml.j2
+++ b/traefik/templates/service-ui.yaml.j2
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Service
-spec:
-  ports:
-    - port: {{ network.port.ui }}
-  selector:
-    app: traefik

--- a/traefik/templates/service.yaml.j2
+++ b/traefik/templates/service.yaml.j2
@@ -5,9 +5,6 @@ spec:
   ports:
     - name: http
       port: 80
-      nodePort: {{ network.port.http }}
-    - name: https
-      port: 443
-      nodePort: {{ network.port.https }}
+      nodePort: {{ network.ingress.port }}
   selector:
     app: traefik


### PR DESCRIPTION
The Traefik service itself wasn't using the port defined in https://github.com/stackanetes/stackanetes/blob/500c2fc/stackanetes/parameters.yaml#L44. Thus, changing the port was breaking external access.