### PR TITLE
nova: report VMs' memory usage as part of the nova-compute pods

### DIFF
--- a/nova/manifest.jsonnet
+++ b/nova/manifest.jsonnet
@@ -75,6 +75,11 @@ kpm.package({
       virt_type: "kvm",
       
       drain_timeout: 60,
+
+      memory: {
+        request: "8Gi",
+        limit: "16Gi"
+      },
     },
 
     database: {
@@ -235,6 +240,20 @@ kpm.package({
       file: "configmaps/virsh-set-secret.sh.yaml.j2",
       template: (importstr "templates/configmaps/virsh-set-secret.sh.yaml.j2"),
       name: "nova-virshsetsecretsh",
+      type: "configmap",
+    },
+
+    {
+      file: "configmaps/init.py.yaml.j2",
+      template: (importstr "templates/configmaps/init.py.yaml.j2"),
+      name: "nova-initpy",
+      type: "configmap",
+    },
+
+    {
+      file: "configmaps/driver.py.yaml.j2",
+      template: (importstr "templates/configmaps/driver.py.yaml.j2"),
+      name: "nova-driverpy",
       type: "configmap",
     },
 

--- a/nova/templates/compute/compute.yaml.j2
+++ b/nova/templates/compute/compute.yaml.j2
@@ -7,6 +7,9 @@ spec:
       labels:
         app: nova-compute
       annotations:
+        {% if deployment.engine == "rkt" -%}
+        rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
+        {%- endif %}
         # TODO: When implemented upstream, replace the pod affinity with
         # requiredDuringSchedulingRequiredDuringExecution
         scheduler.alpha.kubernetes.io/affinity: >
@@ -54,6 +57,9 @@ spec:
       securityContext:
         runAsUser: 0
       hostNetwork: true
+      {% if deployment.engine != "rkt" -%}
+      hostPID: true
+      {%- endif %}
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ nova.drain_timeout }}
       containers:
@@ -69,6 +75,11 @@ spec:
             preStop:
               exec:
                 command: ["python", "/tmp/hooks.py", "prestop_compute"]
+          resources:
+            requests:
+              memory: "{{ nova.memory.request }}"
+            limits:
+              memory: "{{ nova.memory.limit }}"
           env:
             - name: INTERFACE_NAME
               value: {{ network.minion_interface_name }}
@@ -80,6 +91,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: MEM_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
             - name: COMMAND
               value: "bash /tmp/nova.sh"
             - name: DEPENDENCY_JOBS
@@ -102,17 +117,25 @@ spec:
             - name: cephclientcinderkeyring
               mountPath: /etc/ceph/ceph.client.{{ ceph.cinder_user }}.keyring
               subPath: ceph.client.{{ ceph.cinder_user }}.keyring
+            - name: novadriverpy
+              mountPath: /var/lib/kolla/venv/lib/python2.7/site-packages/nova/virt/k8slibvirt/driver.py
+              subPath: driver.py
+            - name: novainitpy
+              mountPath: /var/lib/kolla/venv/lib/python2.7/site-packages/nova/virt/k8slibvirt/__init__.py
+              subPath: __init__.py
+            {% if deployment.engine != "rkt" -%}
             - mountPath: /lib/modules
               name: libmodules
               readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            {%- endif %}
             - mountPath: /var/lib/nova
               name: varlibnova
             - mountPath: /var/lib/libvirt
               name: varliblibvirt
             - mountPath: /run
               name: run
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
             - mountPath: /etc/resolv.conf
               name: resolvconf
               subPath: resolv.conf
@@ -144,9 +167,12 @@ spec:
         - name: virshsetsecretsh
           configMap:
             name: nova-virshsetsecretsh
-        - name: libmodules
-          hostPath:
-            path: /lib/modules
+        - name: novadriverpy
+          configMap:
+            name: nova-driverpy
+        - name: novainitpy
+          configMap:
+            name: nova-initpy
         - name: varlibnova
           hostPath:
             path: /var/lib/nova
@@ -156,9 +182,14 @@ spec:
         - name: run
           hostPath:
             path: /run
+        {% if deployment.engine != "rkt" -%}
+        - name: libmodules
+          hostPath:
+            path: /lib/modules
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
+        {%- endif %}
         - name: openrcyaml
           configMap:
             name: nova-openrcyaml

--- a/nova/templates/configmaps/driver.py.yaml.j2
+++ b/nova/templates/configmaps/driver.py.yaml.j2
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  driver.py: |+
+    import os
+    import types
+    import subprocess
+
+    from nova.virt.libvirt.driver import LibvirtDriver
+    from nova.compute import power_state
+
+    from oslo_log import log as logging
+    from oslo_service import loopingcall
+
+    LOG = logging.getLogger(__name__)
+    SYS_FS_CGROUP = "/sys/fs/cgroup/"
+
+
+    class K8sLibvirtDriver(LibvirtDriver):
+        def _get_compute_cgroup(self):
+            return subprocess.check_output(["bash", "-c", "cat /proc/self/cgroup | head -n 1 | awk -F ':' '{print $3}'"]).strip()
+
+        def _get_guest_pid(self, guest):
+            LOG.info(guest.uuid)
+            return subprocess.check_output(["pgrep", "-f", guest.uuid]).strip()
+
+        def _get_cgroup_value(self, controller, cgroup, file):
+            fpath = os.path.join(SYS_FS_CGROUP, controller, cgroup.lstrip("/"), file)
+            with open(fpath, 'r') as f:
+                return f.readline().strip()
+
+        def _set_cgroup_value(self, controller, cgroup, file, value):
+            fpath = os.path.join(SYS_FS_CGROUP, controller, cgroup.lstrip("/"), file)
+            with open(fpath, 'w') as f:
+                f.write(str(value))
+
+        def get_available_resource(self, nodename):
+            data = super(K8sLibvirtDriver, self).get_available_resource(nodename)
+
+            if os.getenv("MEM_REQUEST"):
+                data["memory_mb"] = int(os.getenv("MEM_REQUEST")) / (1024 ** 2)
+
+                compute_cgroup = self._get_compute_cgroup()
+                if compute_cgroup:
+                    data["memory_mb_used"] = int(self._get_cgroup_value("memory", compute_cgroup, "memory.memsw.usage_in_bytes")) / (1024 ** 2)
+
+            return data
+
+        def _create_domain(self, xml=None, domain=None,
+                           power_on=True, pause=False, post_xml_callback=None):
+            guest = super(K8sLibvirtDriver, self)._create_domain(xml, domain,
+                                                                 power_on, pause,
+                                                                 post_xml_callback)
+
+            if not power_on:
+                return guest
+
+            def _wait_for_boot():
+                state = guest.get_power_state(self._host)
+                if state in (power_state.RUNNING, power_state.PAUSED):
+                    raise loopingcall.LoopingCallDone()
+
+            timer = loopingcall.FixedIntervalLoopingCall(_wait_for_boot)
+            timer.start(interval=0.5).wait()
+
+            compute_cgroup = self._get_compute_cgroup()
+            guest_pid = self._get_guest_pid(guest)
+
+            if not compute_cgroup or not guest_pid:
+                LOG.warning(
+                    "Could not find guest's process or Nova's cgroup",
+                    uuid=guest.uuid)
+                return guest
+
+            LOG.info("Moving guest's process to Nova's cgroup.",
+                     uuid=guest.uuid, pid=guest_pid, cgroup=compute_cgroup)
+
+            self._set_cgroup_value("memory", compute_cgroup, "memory.move_charge_at_immigrate", 0b11)
+            self._set_cgroup_value("memory", compute_cgroup, "tasks", guest_pid)
+
+            return guest

--- a/nova/templates/configmaps/hooks.py.yaml.j2
+++ b/nova/templates/configmaps/hooks.py.yaml.j2
@@ -81,17 +81,6 @@ data:
             sys.exit(0)
 
 
-    def check_node_status(hostname):
-        v1 = k8sclient.CoreV1Api()
-        nodes = v1.list_node(watch=False)
-        for node in nodes.items:
-            if hostname == node.metadata.name:
-                return node.spec.unschedulable
-
-        print "Cannot find node {}".format(hostname)
-        sys.exit(1)
-
-
     def get_all_vms_deployed_on_host(nclient, hostname):
         try:
             vms = nclient.servers.findall(**{"OS-EXT-SRV-ATTR:host": hostname})
@@ -152,14 +141,10 @@ data:
 
 
     def prestop_compute(hostname):
-        # check whether node is unschedulable
-        if check_node_status(hostname):
-            print "Node is drained."
-            nova_client = get_nova_client()
-            disable_node(nova_client, hostname)
-            live_migrate_host(nova_client, hostname)
-        else:
-            print "Node is in a schedulable state. Nova-compute is shutting down."
+        print "Node is drained."
+        nova_client = get_nova_client()
+        disable_node(nova_client, hostname)
+        live_migrate_host(nova_client, hostname)
 
 
     def prestop_libvirt(hostname):

--- a/nova/templates/configmaps/init.py.yaml.j2
+++ b/nova/templates/configmaps/init.py.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  __init__.py: |+
+    from nova.virt.k8slibvirt import driver
+
+    K8sLibvirtDriver = driver.K8sLibvirtDriver
+
+

--- a/nova/templates/configmaps/nova.conf.yaml.j2
+++ b/nova/templates/configmaps/nova.conf.yaml.j2
@@ -9,6 +9,7 @@ data:
     ram_allocation_ratio=1.0
     disk_allocation_ratio=1.0
     cpu_allocation_ratio=3.0
+    reserved_host_memory_mb=0
 
     state_path = /var/lib/nova
 
@@ -25,7 +26,7 @@ data:
 
     allow_resize_to_same_host = True
 
-    compute_driver = libvirt.LibvirtDriver
+    compute_driver = k8slibvirt.K8sLibvirtDriver
 
     # Though my_ip is not used directly, lots of other variables use $my_ip
     my_ip = {{ network.ip_address }}


### PR DESCRIPTION
By moving the VM processes to the nova-compute container's
memory cgroup, Kubernetes can correctly monitor the memory
that Nova Compute and its VMs consume. Therefore, operators
have a better vision of what Nova represents on their nodes,
and we give Kubernetes the opportunity to manage the hosts'
resources appropriately given the actual load, the defined
QoS, etc. For instance, if a Nova instance ends up consuming
more than it is allowed to, or if that Nova instance has a
lesser priority than other workloads, Kubernetes could decide
to kill the pod, thus distributing all VMs across other
available Nova pods using the preStop hook.

We also propagate the memory request set for the Nova pod to
the Nova scheduler, so that the scheduler can make better
decisions, and the hypervisor is shown with the correct amount
of memory available.

Fixes #140